### PR TITLE
allow exponential backoff when pausing

### DIFF
--- a/lib/kafka/consumer.rb
+++ b/lib/kafka/consumer.rb
@@ -1,6 +1,7 @@
 require "kafka/consumer_group"
 require "kafka/offset_manager"
 require "kafka/fetch_operation"
+require "kafka/pause"
 
 module Kafka
 
@@ -49,8 +50,11 @@ module Kafka
       @session_timeout = session_timeout
       @heartbeat = heartbeat
 
-      # A list of partitions that have been paused, per topic.
-      @paused_partitions = {}
+      @pauses = Hash.new {|h, k|
+        h[k] = Hash.new {|h2, k2|
+          h2[k2] = Pause.new
+        }
+      }
 
       # Whether or not the consumer is currently consuming messages.
       @running = false
@@ -115,16 +119,28 @@ module Kafka
     # the rest of the partitions to continue being processed.
     #
     # If the `timeout` argument is passed, the partition will automatically be
-    # resumed when the timeout expires.
+    # resumed when the timeout expires. If `exponential_backoff` is enabled, each
+    # subsequent pause will cause the timeout to double until a message from the
+    # partition has been successfully processed.
     #
     # @param topic [String]
     # @param partition [Integer]
-    # @param timeout [Integer] the number of seconds to pause the partition for,
+    # @param timeout [nil, Integer] the number of seconds to pause the partition for,
     #   or `nil` if the partition should not be automatically resumed.
+    # @param max_timeout [nil, Integer] the maximum number of seconds to pause for,
+    #   or `nil` if no maximum should be enforced.
+    # @param exponential_backoff [Boolean] whether to enable exponential backoff.
     # @return [nil]
-    def pause(topic, partition, timeout: nil)
-      @paused_partitions[topic] ||= {}
-      @paused_partitions[topic][partition] = timeout && Time.now + timeout
+    def pause(topic, partition, timeout: nil, max_timeout: nil, exponential_backoff: false)
+      if max_timeout && !exponential_backoff
+        raise ArgumentError, "`max_timeout` only makes sense when `exponential_backoff` is enabled"
+      end
+
+      pause_for(topic, partition).pause!(
+        timeout: timeout,
+        max_timeout: max_timeout,
+        exponential_backoff: exponential_backoff,
+      )
     end
 
     # Resume processing of a topic partition.
@@ -134,8 +150,7 @@ module Kafka
     # @param partition [Integer]
     # @return [nil]
     def resume(topic, partition)
-      paused_partitions = @paused_partitions.fetch(topic, {})
-      paused_partitions.delete(partition)
+      pause_for(topic, partition).resume!
     end
 
     # Whether the topic partition is currently paused.
@@ -145,24 +160,8 @@ module Kafka
     # @param partition [Integer]
     # @return [Boolean] true if the partition is paused, false otherwise.
     def paused?(topic, partition)
-      partitions = @paused_partitions.fetch(topic, {})
-
-      if partitions.key?(partition)
-        # Users can set an optional timeout, after which the partition is
-        # automatically resumed. When pausing, the timeout is translated to an
-        # absolute point in time.
-        timeout = partitions.fetch(partition)
-
-        if timeout.nil?
-          true
-        elsif Time.now < timeout
-          true
-        else
-          @logger.info "Automatically resuming partition #{topic}/#{partition}, pause timeout expired"
-          resume(topic, partition)
-          false
-        end
-      end
+      pause = pause_for(topic, partition)
+      pause.paused? && !pause.expired?
     end
 
     # Fetches and enumerates the messages in the topics that the consumer group
@@ -229,6 +228,10 @@ module Kafka
 
             return if !@running
           end
+
+          # We've successfully processed a batch from the partition, so we can clear
+          # the pause.
+          pause_for(batch.topic, batch.partition).reset!
         end
 
         # We may not have received any messages, but it's still a good idea to
@@ -295,6 +298,10 @@ module Kafka
             end
 
             mark_message_as_processed(batch.messages.last) if automatically_mark_as_processed
+
+            # We've successfully processed a batch from the partition, so we can clear
+            # the pause.
+            pause_for(batch.topic, batch.partition).reset!
           end
 
           @offset_manager.commit_offsets_if_necessary
@@ -400,12 +407,26 @@ module Kafka
       end
     end
 
+    def resume_paused_partitions!
+      @pauses.each do |topic, partitions|
+        partitions.each do |partition, pause|
+
+          if pause.paused? && pause.expired?
+            @logger.info "Automatically resuming partition #{topic}/#{partition}, pause timeout expired"
+            resume(topic, partition)
+          end
+        end
+      end
+    end
+
     def fetch_batches(min_bytes:, max_wait_time:, automatically_mark_as_processed:)
       join_group unless @group.member?
 
       subscribed_partitions = @group.subscribed_partitions
 
       @heartbeat.send_if_necessary
+
+      resume_paused_partitions!
 
       operation = FetchOperation.new(
         cluster: @cluster,
@@ -458,5 +479,10 @@ module Kafka
 
       raise FetchError, e
     end
+
+    def pause_for(topic, partition)
+      @pauses[topic][partition]
+    end
+
   end
 end

--- a/lib/kafka/pause.rb
+++ b/lib/kafka/pause.rb
@@ -1,0 +1,90 @@
+module Kafka
+  # Manages the pause state of a partition.
+  #
+  # The processing of messages in a partition can be paused, e.g. if there was
+  # an exception during processing. This could be caused by a downstream service
+  # not being available. A typical way of solving such an issue is to back off
+  # for a little while and then try again. In order to do that, _pause_ the
+  # partition.
+  class Pause
+    def initialize(clock: Time)
+      @clock = clock
+      @started_at = nil
+      @pauses = 0
+      @timeout = nil
+      @max_timeout = nil
+      @exponential_backoff = false
+    end
+
+    # Mark the partition as paused.
+    #
+    # If exponential backoff is enabled, each subsequent pause of a partition will
+    # cause a doubling of the actual timeout, i.e. for pause number _n_, the actual
+    # timeout will be _2^n * timeout_.
+    #
+    # Only when {#reset!} is called is this state cleared.
+    #
+    # @param timeout [nil, Integer] if specified, the partition will automatically
+    #   resume after this many seconds.
+    # @param exponential_backoff [Boolean] whether to enable exponential timeouts.
+    def pause!(timeout: nil, max_timeout: nil, exponential_backoff: false)
+      @started_at = @clock.now
+      @timeout = timeout
+      @max_timeout = max_timeout
+      @exponential_backoff = exponential_backoff
+      @pauses += 1
+    end
+
+    # Resumes the partition.
+    #
+    # The number of pauses is still retained, and if the partition is paused again
+    # it may be with an exponential backoff.
+    def resume!
+      @started_at = nil
+      @timeout = nil
+      @max_timeout = nil
+    end
+
+    # Whether the partition is currently paused. The pause may have expired, in which
+    # case {#expired?} should be checked as well.
+    def paused?
+      # This is nil if we're not currently paused.
+      !@started_at.nil?
+    end
+
+    def pause_duration
+      if paused?
+        Time.now - @started_at
+      else
+        0
+      end
+    end
+
+    # Whether the pause has expired.
+    def expired?
+      # We never expire the pause if timeout is nil.
+      return false if @timeout.nil?
+
+      # Have we passed the end of the pause duration?
+      @clock.now >= ends_at
+    end
+
+    # Resets the pause state, ensuring that the next pause is not exponential.
+    def reset!
+      @pauses = 0
+    end
+
+    private
+
+    def ends_at
+      # Apply an exponential backoff to the timeout.
+      backoff_factor = @exponential_backoff ? 2**(@pauses - 1) : 1
+      timeout = backoff_factor * @timeout
+
+      # If set, don't allow a timeout longer than max_timeout.
+      timeout = @max_timeout if @max_timeout && timeout > @max_timeout
+
+      @started_at + timeout
+    end
+  end
+end

--- a/ruby-kafka.gemspec
+++ b/ruby-kafka.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "snappy"
   spec.add_development_dependency "colored"
   spec.add_development_dependency "rspec_junit_formatter", "0.2.2"
-  spec.add_development_dependency "dogstatsd-ruby", ">= 3.0.0"
+  spec.add_development_dependency "dogstatsd-ruby", "~> 3.0.0"
   spec.add_development_dependency "statsd-ruby"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "timecop"

--- a/spec/pause_spec.rb
+++ b/spec/pause_spec.rb
@@ -1,0 +1,77 @@
+require "ostruct"
+
+describe Kafka::Pause do
+  let(:clock) { OpenStruct.new(now: 30) }
+  let(:pause) { Kafka::Pause.new(clock: clock) }
+
+  describe "#paused?" do
+    it "returns true if we're paused" do
+      pause.pause!
+
+      expect(pause.paused?).to eq true
+    end
+
+    it "returns false if we're not paused" do
+      pause.pause!
+      pause.resume!
+
+      expect(pause.paused?).to eq false
+    end
+  end
+
+  describe "#expired?" do
+    it "returns false if no timeout was specified" do
+      pause.pause!
+      expect(pause.expired?).to eq false
+    end
+
+    it "returns false if the timeout has not yet passed" do
+      pause.pause!(timeout: 10)
+
+      clock.now = 39
+
+      expect(pause.expired?).to eq false
+    end
+
+    it "returns true if the timeout has passed" do
+      pause.pause!(timeout: 10)
+
+      clock.now = 40
+
+      expect(pause.expired?).to eq true
+    end
+
+    context "with exponential backoff" do
+      it "doubles the timeout with each attempt" do
+        pause.pause!(timeout: 10, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, exponential_backoff: true)
+
+        expect(pause.expired?).to eq false
+
+        clock.now += 10 + 20 + 40
+
+        expect(pause.expired?).to eq true
+        expect(pause.expired?).to eq true
+      end
+
+      it "never pauses for more than the max timeout" do
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+        pause.resume!
+        pause.pause!(timeout: 10, max_timeout: 30, exponential_backoff: true)
+
+        clock.now += 29
+
+        expect(pause.expired?).to eq false
+
+        clock.now += 1
+
+        expect(pause.expired?).to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
**WIP**

Adds pausing capabilities with exponential backoffs to our ruby-kafka fork.

These commits and files were cherry-picked from upstream commits (later versions of the library) and backported to the v0.5 version of library that is compatible with our Kafka version (0.10.1).